### PR TITLE
Specify dates for activity dashboard and Color table cells

### DIFF
--- a/src/app/activity-dashboard/activity-dashboard.component.html
+++ b/src/app/activity-dashboard/activity-dashboard.component.html
@@ -1,3 +1,33 @@
+<div>
+  <mat-grid-list cols="4" rowHeight="80px">
+    <mat-grid-tile>
+      <div class="grid-flush-left">
+        <h1 class="mat-headline" style="margin: 0px">Activity</h1>
+      </div>
+    </mat-grid-tile>
+
+    <mat-grid-tile>
+      <mat-form-field appearance="fill">
+        <mat-label>Start Date</mat-label>
+        <input matInput [min]="startMinDate" [max]="startMaxDate" [matDatepicker]="startPicker" (dateChange)="pickStartDate($event)" />
+        <mat-hint>MM/DD/YYYY</mat-hint>
+        <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
+        <mat-datepicker startView="year" #startPicker></mat-datepicker>
+      </mat-form-field>
+    </mat-grid-tile>
+
+    <mat-grid-tile>
+      <mat-form-field appearance="fill">
+        <mat-label>End Date</mat-label>
+        <input matInput [min]="endMinDate" [max]="endMaxDate" [matDatepicker]="endPicker" (dateChange)="pickEndDate($event)" />
+        <mat-hint>MM/DD/YYYY</mat-hint>
+        <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
+        <mat-datepicker startView="year" #endPicker></mat-datepicker>
+      </mat-form-field>
+    </mat-grid-tile>
+  </mat-grid-list>
+</div>
+
 <div style="display: flex">
   <app-event-tables
     *ngFor="let assignee of assignees"

--- a/src/app/activity-dashboard/activity-dashboard.component.ts
+++ b/src/app/activity-dashboard/activity-dashboard.component.ts
@@ -1,9 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, QueryList, ViewChildren } from '@angular/core';
+import { MatDatepickerInputEvent } from '@angular/material/datepicker';
+import * as moment from 'moment';
 import { GithubUser } from '../core/models/github-user.model';
 import { GithubService } from '../core/services/github.service';
 import { GithubEventService } from '../core/services/githubevent.service';
 import { EXPANDED_TABLE_COLUMNS, TABLE_COLUMNS } from './event-tables/event-tables-columns';
-import { ACTION_BUTTONS } from './event-tables/event-tables.component';
+import { ACTION_BUTTONS, EventTablesComponent } from './event-tables/event-tables.component';
 
 @Component({
   selector: 'app-activity-dashboard',
@@ -15,12 +17,29 @@ export class ActivityDashboardComponent implements OnInit {
   readonly expandedColumns = [EXPANDED_TABLE_COLUMNS.ID, EXPANDED_TABLE_COLUMNS.TITLE, EXPANDED_TABLE_COLUMNS.DATE];
   readonly actionButtons: ACTION_BUTTONS[] = [ACTION_BUTTONS.VIEW_IN_WEB];
 
+  startMinDate: Date;
+  startMaxDate = moment().endOf('day').toDate();
+  endMinDate: Date;
+  endMaxDate = moment().endOf('day').toDate();
+
   assignees: GithubUser[];
+
+  @ViewChildren(EventTablesComponent) tables: QueryList<EventTablesComponent>;
 
   constructor(private githubService: GithubService, private githubEventService: GithubEventService) {}
 
   ngOnInit() {
     this.githubEventService.getEvents();
     this.githubService.getUsersAssignable().subscribe((x) => (this.assignees = x));
+  }
+
+  pickStartDate(event: MatDatepickerInputEvent<Date>) {
+    this.endMinDate = event.value;
+    this.tables.forEach((t) => (t.githubEvents.start = `${event.value}`));
+  }
+
+  pickEndDate(event: MatDatepickerInputEvent<Date>) {
+    this.startMaxDate = event.value;
+    this.tables.forEach((t) => (t.githubEvents.end = `${event.value}`));
   }
 }

--- a/src/app/activity-dashboard/activity-dashboard.module.ts
+++ b/src/app/activity-dashboard/activity-dashboard.module.ts
@@ -1,9 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { SharedModule } from '../shared/shared.module';
 import { ActivityDashboardRoutingModule } from './activity-dashboard-routing.module';
 import { ActivityDashboardComponent } from './activity-dashboard.component';
 import { EventTablesModule } from './event-tables/event-tables.module';
-import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
   declarations: [ActivityDashboardComponent],

--- a/src/app/activity-dashboard/activity-dashboard.module.ts
+++ b/src/app/activity-dashboard/activity-dashboard.module.ts
@@ -3,9 +3,10 @@ import { NgModule } from '@angular/core';
 import { ActivityDashboardRoutingModule } from './activity-dashboard-routing.module';
 import { ActivityDashboardComponent } from './activity-dashboard.component';
 import { EventTablesModule } from './event-tables/event-tables.module';
+import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
   declarations: [ActivityDashboardComponent],
-  imports: [CommonModule, ActivityDashboardRoutingModule, EventTablesModule]
+  imports: [CommonModule, SharedModule, ActivityDashboardRoutingModule, EventTablesModule]
 })
 export class ActivityDashboardModule {}

--- a/src/app/activity-dashboard/event-tables/GithubEventDataTable.ts
+++ b/src/app/activity-dashboard/event-tables/GithubEventDataTable.ts
@@ -10,6 +10,8 @@ import { EventWeek } from '../event-week.model';
 import { paginateData } from './event-paginator';
 
 export class GithubEventDataTable extends DataSource<EventWeek> {
+  private startDate = new BehaviorSubject('');
+  private endDate = new BehaviorSubject('');
   private eventsSubject = new BehaviorSubject<EventWeek[]>([]);
   private eventSubscription: Subscription;
 
@@ -30,14 +32,17 @@ export class GithubEventDataTable extends DataSource<EventWeek> {
   }
 
   disconnect() {
+    this.startDate.complete();
+    this.endDate.complete();
     this.eventsSubject.complete();
     this.eventSubscription.unsubscribe();
   }
 
   /** Group GithubEvents[] week by week */
   groupByWeeks(githubEvents: GithubEvent[]): EventWeek[] {
-    // const endDate = moment();  // now
-    const startDate = moment().subtract(1, 'month').startOf('day'); // to pass in as argument?
+    const endDate = this.startDate.getValue() === '' ? moment() : moment(this.endDate.getValue());
+    const startDate =
+      this.startDate.getValue() === '' ? endDate.clone().subtract(1, 'month').startOf('day') : moment(this.startDate.getValue());
     let loopDate = moment(startDate).day('Sunday');
     const eventWeeks = [];
     let eventsInAWeek = [];
@@ -58,16 +63,19 @@ export class GithubEventDataTable extends DataSource<EventWeek> {
         // event in later week
         eventWeeks.push(EventWeek.of(loopDate.format('ll'), eventsInAWeek)); // push previous week
         eventsInAWeek = [];
-        loopDate = loopDate.add(7, 'days');
+        loopDate.add(7, 'days');
 
         // Empty weeks if any
-        while (loopDate.clone().add(7, 'days').isBefore(eventDate)) {
+        while (loopDate.clone().add(7, 'days').isBefore(eventDate) && loopDate.clone().add(7, 'days').isBefore(endDate)) {
           eventWeeks.push(EventWeek.of(loopDate.format('ll'), []));
-          loopDate = loopDate.add(7, 'days');
+          loopDate.add(7, 'days');
         }
 
         console.assert(loopDate.clone().add(7, 'days').isAfter(eventDate) && loopDate.isBefore(eventDate));
-        eventsInAWeek.push(githubEvent);
+
+        if (eventDate.isBefore(endDate)) {
+          eventsInAWeek.push(githubEvent);
+        }
       }
     });
 
@@ -88,7 +96,7 @@ export class GithubEventDataTable extends DataSource<EventWeek> {
       page = this.paginator.page;
     }
 
-    const displayDataChanges = [page, sortChange].filter((x) => x !== undefined);
+    const displayDataChanges = [page, sortChange, this.startDate, this.endDate].filter((x) => x !== undefined);
 
     this.githubEventService.pollEvents();
     console.log('log');
@@ -133,5 +141,21 @@ export class GithubEventDataTable extends DataSource<EventWeek> {
         console.log(data);
         this.eventsSubject.next(data);
       });
+  }
+
+  get start(): string {
+    return this.startDate.value;
+  }
+
+  set start(date: string) {
+    this.startDate.next(date);
+  }
+
+  get end(): string {
+    return this.endDate.value;
+  }
+
+  set end(date: string) {
+    this.endDate.next(date);
   }
 }

--- a/src/app/activity-dashboard/event-tables/GithubEventDataTable.ts
+++ b/src/app/activity-dashboard/event-tables/GithubEventDataTable.ts
@@ -43,7 +43,7 @@ export class GithubEventDataTable extends DataSource<EventWeek> {
     const endDate = this.startDate.getValue() === '' ? moment() : moment(this.endDate.getValue());
     const startDate =
       this.startDate.getValue() === '' ? endDate.clone().subtract(1, 'month').startOf('day') : moment(this.startDate.getValue());
-    let loopDate = moment(startDate).day('Sunday');
+    const loopDate = moment(startDate).day('Sunday');
     const eventWeeks = [];
     let eventsInAWeek = [];
     let weekNum = 1;

--- a/src/app/activity-dashboard/event-tables/event-tables.component.css
+++ b/src/app/activity-dashboard/event-tables/event-tables.component.css
@@ -31,3 +31,17 @@
   display: flex;
   width: 100%;
 }
+
+/* Colour cells */
+
+.white {
+  background-color: white;
+}
+
+.pale-green {
+  background-color: palegreen;
+}
+
+.green {
+  background-color: green;
+}

--- a/src/app/activity-dashboard/event-tables/event-tables.component.html
+++ b/src/app/activity-dashboard/event-tables/event-tables.component.html
@@ -4,11 +4,47 @@
   </h1>
 
   <mat-table [dataSource]="this.githubEvents" matSort multiTemplateDataRows class="mat-elevation-z8">
-    <ng-container matColumnDef="{{ column }}" *ngFor="let column of columnsToDisplay">
+    <!-- <ng-container matColumnDef="{{ column }}" *ngFor="let column of columnsToDisplay">
       <mat-header-cell *matHeaderCellDef mat-sort-header> {{ column }} </mat-header-cell>
       <mat-cell *matCellDef="let element">
         <span (click)="$event.stopPropagation()" style="cursor: default">
           {{ element[column] }}
+        </span>
+      </mat-cell>
+    </ng-container> -->
+
+    <ng-container matColumnDef="date_start">
+      <mat-header-cell *matHeaderCellDef mat-sort-header> Date </mat-header-cell>
+      <mat-cell *matCellDef="let element">
+        <span (click)="$event.stopPropagation()" style="cursor: default">
+          {{ element.date_start }}
+        </span>
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="issue_count">
+      <mat-header-cell *matHeaderCellDef mat-sort-header> Issue # </mat-header-cell>
+      <mat-cell *matCellDef="let element" [ngClass]="colorCell(element.issue_count)">
+        <span (click)="$event.stopPropagation()" style="cursor: default">
+          {{ element.issue_count }}
+        </span>
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="pr_count">
+      <mat-header-cell *matHeaderCellDef mat-sort-header> PR # </mat-header-cell>
+      <mat-cell *matCellDef="let element" [ngClass]="colorCell(element.pr_count)">
+        <span (click)="$event.stopPropagation()" style="cursor: default">
+          {{ element.pr_count }}
+        </span>
+      </mat-cell>
+    </ng-container>
+
+    <ng-container matColumnDef="comment_count">
+      <mat-header-cell *matHeaderCellDef mat-sort-header> Comment # </mat-header-cell>
+      <mat-cell *matCellDef="let element" [ngClass]="colorCell(element.comment_count)">
+        <span (click)="$event.stopPropagation()" style="cursor: default">
+          {{ element.comment_count }}
         </span>
       </mat-cell>
     </ng-container>

--- a/src/app/activity-dashboard/event-tables/event-tables.component.ts
+++ b/src/app/activity-dashboard/event-tables/event-tables.component.ts
@@ -96,4 +96,14 @@ export class EventTablesComponent implements OnInit, AfterViewInit {
       this.expandedElement = this.expandedElement === element ? null : element;
     }
   }
+
+  colorCell(count: number) {
+    if (count == 0) {
+      return 'white';
+    } else if (count > 0 && count <= 5) {
+      return 'pale-green';
+    } else if (count > 6) {
+      return 'green';
+    }
+  }
 }

--- a/src/app/activity-dashboard/event-tables/event-tables.component.ts
+++ b/src/app/activity-dashboard/event-tables/event-tables.component.ts
@@ -98,7 +98,7 @@ export class EventTablesComponent implements OnInit, AfterViewInit {
   }
 
   colorCell(count: number) {
-    if (count == 0) {
+    if (count === 0) {
       return 'white';
     } else if (count > 0 && count <= 5) {
       return 'pale-green';

--- a/src/app/activity-dashboard/event-week.model.ts
+++ b/src/app/activity-dashboard/event-week.model.ts
@@ -17,7 +17,7 @@ export class EventWeek {
 
   constructor(eventWeek: {}) {
     Object.assign(this, eventWeek);
-    this.date_start = moment(eventWeek['date_start']).format('ll');
+    this.date_start = moment(eventWeek['date_start']).format('D/M');
   }
 
   public static of(dateStart: string, githubEvents: GithubEvent[]): EventWeek {


### PR DESCRIPTION
### Summary:


### Changes Made:

- Select start and end date of activity dashboard
  - Start date and end date have min max to ensure no crossing dates
- Simple cell colouring by count of issues/pr/comments

### Commit Message:

```
Let's specify dates for activity dashboard and color table cells.
```
